### PR TITLE
Add extra icon type helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,29 @@ fa_icon('camera-retro', type: :fab)
      
 ```  
 
+Each icon type has its own helper method so you don't need to provide the ```type``` attribute in every call.
+Which can be overridden, if it is provided.
+```ruby
+far_icon('camera-retro')
+# => <i class="far fa-camera-retro"></i>
+
+far_icon('camera-retro', type: :fab)
+# => <i class="fab fa-camera-retro"></i>
+
+far_stacked_icon('camera', base: 'circle')
+# => <span class="fa-stack">
+# =>   <i class="far fa-circle fa-stack-2x"></i>
+# =>   <i class="far fa-camera fa-stack-1x"></i>
+# => </span>
+
+far_stacked_icon('camera', base: 'circle', type: :fal)
+# => <span class="fa-stack">
+# =>   <i class="fal fa-circle fa-stack-2x"></i>
+# =>   <i class="fal fa-camera fa-stack-1x"></i>
+# => </span>
+
+```
+
 ### Animations and data attributes
 FontAwesome 5 provides new animations and data attributes. Here are some examples how to use them:
 ```ruby

--- a/app/helpers/font_awesome5/rails/icon_helper.rb
+++ b/app/helpers/font_awesome5/rails/icon_helper.rb
@@ -39,6 +39,18 @@ module FontAwesome5
         end
       end
 
+      %w(fas far fal fab).each do |type|
+        define_method :"#{type}_icon" do |icon, options = {}|
+          options[:type] = type.to_sym unless options.key? :type
+          fa_icon(icon, options)
+        end
+
+        define_method :"#{type}_stacked_icon" do |icon, options = {}|
+          options[:type] = type.to_sym unless options.key? :type
+          fa_stacked_icon(icon, options)
+        end
+      end
+
     end
   end
 end

--- a/spec/font_awesome5_rails_spec.rb
+++ b/spec/font_awesome5_rails_spec.rb
@@ -169,4 +169,36 @@ describe FontAwesome5Rails do
     end
   end
   
+  describe '[fas, far, fal, fab]_icon helper method' do
+    %w(fas far fal fab).each do |type|
+      it "#{type}_icon should be defined and use the right icon type" do
+        method = :"#{type}_icon"
+
+        expect(self).to respond_to(method)
+        expect(send(method, 'camera-retro')).to eq "<i class=\"#{type} fa-camera-retro\"></i>"
+        expect(send(method, 'camera-retro', type: :fal)).to eq "<i class=\"fal fa-camera-retro\"></i>"
+        expect(send(method, 'camera-retro', type: :brand, class: 'test')).to eq "<i class=\"fab fa-camera-retro test\"></i>"
+      end
+    end
+  end
+
+  describe '[fas, far, fal, fab]_stacked_icon helper method' do
+    %w(fas far fal fab).each do |type|
+      it "#{type}_stacked_icon should be defined and use the right icon type" do
+        method = :"#{type}_stacked_icon"
+
+        expect(self).to respond_to(method)
+
+        expect(send(method, 'camera', base: 'circle'))
+          .to eq "<span class=\"fa-stack\"><i class=\"#{type} fa-circle fa-stack-2x\"></i><i class=\"#{type} fa-camera fa-stack-1x\"></i></span>"
+
+        expect(send(method, 'camera', base: 'circle', type: :fal))
+          .to eq '<span class="fa-stack"><i class="fal fa-circle fa-stack-2x"></i><i class="fal fa-camera fa-stack-1x"></i></span>'
+
+        expect(send(method, 'camera', base: 'circle', type: :brand, reverse: false))
+          .to eq '<span class="fa-stack"><i class="fab fa-circle fa-stack-2x"></i><i class="fab fa-camera fa-stack-1x"></i></span>'
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This pull request provides helper methods for every icon type, so the type attibute does not have to be provided for every method call.

So now instead of calling:
```ruby
fa_icon('camera-retro', type: :fab)
```
you can use
```ruby
fab_icon('camera-retro')
```

Same for ```fa_stacked_icon```