### PR TITLE
Uncap railties dependency

### DIFF
--- a/font_awesome5_rails.gemspec
+++ b/font_awesome5_rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,bin,lib,spec}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "railties", ">= 4.2", "< 5.3"
+  s.add_dependency "railties", ">= 4.2"
 
   s.add_development_dependency "activesupport", ">= 4.2"
   s.add_development_dependency "sass-rails"


### PR DESCRIPTION
gem seems to work fine with railties 6 with Rails 6 beta