### PR TITLE
Add namespacing for Parser classes

### DIFF
--- a/app/helpers/font_awesome5/rails/icon_helper.rb
+++ b/app/helpers/font_awesome5/rails/icon_helper.rb
@@ -7,13 +7,13 @@ module FontAwesome5
     module IconHelper
 
       def fa5_icon(icon, options = {})
-        parser = FaIconParser.new(icon, options)
+        parser = FontAwesome5Rails::Parsers::FaIconParser.new(icon, options)
         parser.get_content_tag
       end
       alias_method :fa_icon, :fa5_icon
 
       def fa5_stacked_icon(icon, options = {})
-        parser = FaStackedIconParser.new(icon, options)
+        parser = FontAwesome5Rails::Parsers::FaStackedIconParser.new(icon, options)
 
         tags = content_tag :span, class: parser.span_classes, title: parser.title do
           content_tag(:i, nil, class: (parser.reverse ? parser.second_icon_classes : parser.first_icon_classes), **parser.more_options(:base_options) ) +
@@ -25,7 +25,7 @@ module FontAwesome5
       alias_method :fa_stacked_icon, :fa5_stacked_icon
 
       def fa_layered_icon(options = {}, &block)
-        parser = FaLayeredIconParser.new(options)
+        parser = FontAwesome5Rails::Parsers::FaLayeredIconParser.new(options)
         if parser.size.nil?
           content_tag(:span, class: parser.classes, title: parser.title, style: parser.style, &block)
         else

--- a/lib/font_awesome5_rails/parsers/fa_icon_parser.rb
+++ b/lib/font_awesome5_rails/parsers/fa_icon_parser.rb
@@ -1,55 +1,59 @@
 require_relative 'parse_methods'
 
-class FaIconParser
-  include ActionView::Helpers::TagHelper
-  include ParseMethods
+module FontAwesome5Rails
+  module Parsers
+    class FaIconParser
+      include ActionView::Helpers::TagHelper
+      include ParseMethods
 
-  attr_reader :icon, :options, :data, :style, :text, :title, :right, :attrs
+      attr_reader :icon, :options, :data, :style, :text, :title, :right, :attrs
 
-  def initialize(icon, options)
-    @icon = icon
-    @options = options
-    @data = options[:data]
-    @style = options[:style]
-    @text = options[:text]
-    @title = options[:title]
-    @right = options[:right] == true
-    @attrs = options.except(:text, :type, :class, :icon, :animation, :size, :right)
-  end
+      def initialize(icon, options)
+        @icon = icon
+        @options = options
+        @data = options[:data]
+        @style = options[:style]
+        @text = options[:text]
+        @title = options[:title]
+        @right = options[:right] == true
+        @attrs = options.except(:text, :type, :class, :icon, :animation, :size, :right)
+      end
 
-  def classes
-    @classes ||= parse_classes
-  end
+      def classes
+        @classes ||= parse_classes
+      end
 
-  def sizes
-    @sizes ||= @options[:size].nil? ? "" : arr_with_fa(@options[:size]).uniq.join(" ").strip
-  end
+      def sizes
+        @sizes ||= @options[:size].nil? ? "" : arr_with_fa(@options[:size]).uniq.join(" ").strip
+      end
 
-  def get_content_tag
-    if @text.nil?
-      icon_content_tag
-    else
-      @right ? (text_content_tag + icon_content_tag) : (icon_content_tag + text_content_tag)
+      def get_content_tag
+        if @text.nil?
+          icon_content_tag
+        else
+          @right ? (text_content_tag + icon_content_tag) : (icon_content_tag + text_content_tag)
+        end
+      end
+
+      private
+
+      def parse_classes
+        tmp = []
+        tmp << icon_type(@options[:type])
+        tmp += arr_with_fa(@icon)
+        tmp += @options[:class].split(" ") unless @options[:class].nil?
+        tmp += arr_with_fa(@options[:size]) unless @options[:size].nil?
+        tmp += arr_with_fa(@options[:animation]) unless @options[:animation].nil?
+        tmp.uniq.join(" ").strip
+      end
+
+      def icon_content_tag
+        content_tag(:i, nil, class: classes, **@attrs)
+      end
+
+      def text_content_tag
+        content_tag(:span, @text, class: "#{@right ? 'fa5-text-r' : 'fa5-text'}#{' ' unless sizes.blank?}#{sizes}", style: @style)
+      end
     end
-  end
-
-  private
-
-  def parse_classes
-    tmp = []
-    tmp << icon_type(@options[:type])
-    tmp += arr_with_fa(@icon)
-    tmp += @options[:class].split(" ") unless @options[:class].nil?
-    tmp += arr_with_fa(@options[:size]) unless @options[:size].nil?
-    tmp += arr_with_fa(@options[:animation]) unless @options[:animation].nil?
-    tmp.uniq.join(" ").strip
-  end
-
-  def icon_content_tag
-    content_tag(:i, nil, class: classes, **@attrs)
-  end
-
-  def text_content_tag
-    content_tag(:span, @text, class: "#{@right ? 'fa5-text-r' : 'fa5-text'}#{' ' unless sizes.blank?}#{sizes}", style: @style)
   end
 end

--- a/lib/font_awesome5_rails/parsers/fa_layered_icon_parser.rb
+++ b/lib/font_awesome5_rails/parsers/fa_layered_icon_parser.rb
@@ -1,29 +1,32 @@
 require_relative "parse_methods"
 
-class FaLayeredIconParser
-  include ParseMethods
+module FontAwesome5Rails
+  module Parsers
+    class FaLayeredIconParser
+      include ParseMethods
 
-  attr_reader :aligned, :style, :size, :title
+      attr_reader :aligned, :style, :size, :title
 
+      def initialize(options)
+        @aligned = options[:aligned].nil? ? true : options[:aligned]
+        @style = options[:style]
+        @size = options[:size]
+        @title = options[:title]
+        @options = options
+      end
 
-  def initialize(options)
-    @aligned = options[:aligned].nil? ? true : options[:aligned]
-    @style = options[:style]
-    @size = options[:size]
-    @title = options[:title]
-    @options = options
-  end
+      def classes
+        @classes ||= parse_classes
+      end
 
-  def classes
-    @classes ||= parse_classes
-  end
+      private
 
-  private
-
-  def parse_classes
-    tmp = ["fa-layers"]
-    tmp << "fa-fw" if @aligned
-    tmp += @options[:class].split(" ") unless @options[:class].nil?
-    tmp.uniq.join(" ").strip
+      def parse_classes
+        tmp = ["fa-layers"]
+        tmp << "fa-fw" if @aligned
+        tmp += @options[:class].split(" ") unless @options[:class].nil?
+        tmp.uniq.join(" ").strip
+      end
+    end
   end
 end

--- a/lib/font_awesome5_rails/parsers/fa_stacked_icon_parser.rb
+++ b/lib/font_awesome5_rails/parsers/fa_stacked_icon_parser.rb
@@ -1,49 +1,53 @@
 require_relative "parse_methods"
 
-class FaStackedIconParser
-  include ParseMethods
+module FontAwesome5Rails
+  module Parsers
+    class FaStackedIconParser
+      include ParseMethods
 
-  attr_reader :reverse, :options, :span_classes, :first_icon_classes, :second_icon_classes, :text, :title
+      attr_reader :reverse, :options, :span_classes, :first_icon_classes, :second_icon_classes, :text, :title
 
-  def initialize(icon, options)
-    @icon = icon
-    @text = options[:text]
-    @reverse = options[:reverse] == true
-    @title = options[:title]
-    @options = options
-  end
+      def initialize(icon, options)
+        @icon = icon
+        @text = options[:text]
+        @reverse = options[:reverse] == true
+        @title = options[:title]
+        @options = options
+      end
 
-  def span_classes
-    @span_classes ||= parse_span_classes
-  end
+      def span_classes
+        @span_classes ||= parse_span_classes
+      end
 
-  def first_icon_classes
-    @first_icon_classes ||= parse_icon_classes(@options[:base], true)
-  end
+      def first_icon_classes
+        @first_icon_classes ||= parse_icon_classes(@options[:base], true)
+      end
 
-  def second_icon_classes
-    @second_icon_classes ||= parse_icon_classes(@icon, false)
-  end
+      def second_icon_classes
+        @second_icon_classes ||= parse_icon_classes(@icon, false)
+      end
 
-  def more_options(key)
-    options[key] ? options[key].except(:class, :text) : {}
-  end
+      def more_options(key)
+        options[key] ? options[key].except(:class, :text) : {}
+      end
 
-  private
+      private
 
-  def parse_span_classes
-    tmp = ["fa-stack"]
-    tmp += @options[:class].split(" ") unless @options[:class].nil?
-    tmp.uniq.join(" ").strip
-  end
+      def parse_span_classes
+        tmp = ["fa-stack"]
+        tmp += @options[:class].split(" ") unless @options[:class].nil?
+        tmp.uniq.join(" ").strip
+      end
 
-  def parse_icon_classes(klass, first)
-    tmp = []
-    tmp << icon_type(first && @options[:base_type].present? ? @options[:base_type] : @options[:type])
-    tmp += arr_with_fa(klass)
-    tmp << (first ? "fa-stack-2x" : "fa-stack-1x")
-    key = first ? :base_options : :icon_options
-    tmp << options[key][:class] if options[key] && options[key][:class]
-    tmp.uniq.join(" ").strip
+      def parse_icon_classes(klass, first)
+        tmp = []
+        tmp << icon_type(first && @options[:base_type].present? ? @options[:base_type] : @options[:type])
+        tmp += arr_with_fa(klass)
+        tmp << (first ? "fa-stack-2x" : "fa-stack-1x")
+        key = first ? :base_options : :icon_options
+        tmp << options[key][:class] if options[key] && options[key][:class]
+        tmp.uniq.join(" ").strip
+      end
+    end
   end
 end

--- a/lib/font_awesome5_rails/parsers/parse_methods.rb
+++ b/lib/font_awesome5_rails/parsers/parse_methods.rb
@@ -1,40 +1,44 @@
-module ParseMethods
+module FontAwesome5Rails
+  module Parsers
+    module ParseMethods
 
-  def icon_type(type)
-    return "fas" if type.nil?
-    case type.to_sym
-      when :far, :regular
-        "far"
-      when :fal, :light
-        "fal"
-      when :fab, :brand
-        "fab"
-      when :fad, :duotone
-        "fad"
-      else
-        "fas"
-    end
-  end
+      def icon_type(type)
+        return "fas" if type.nil?
+        case type.to_sym
+        when :far, :regular
+          "far"
+        when :fal, :light
+          "fal"
+        when :fab, :brand
+          "fab"
+        when :fad, :duotone
+          "fad"
+        else
+          "fas"
+        end
+      end
 
-  def prepend_fa(string)
-    "fa-#{string}"
-  end
+      def prepend_fa(string)
+        "fa-#{string}"
+      end
 
-  def arr_with_fa(array)
-    array = handle_input(array)
-    array.split(" ").map{ |s| prepend_fa(s) }
-  end
+      def arr_with_fa(array)
+        array = handle_input(array)
+        array.split(" ").map { |s| prepend_fa(s) }
+      end
 
-  private
+      private
 
-  def handle_input(input)
-    case input
-    when Symbol
-      input.to_s.dasherize
-    when Array
-      input.join(' ').dasherize
-    else
-      input.to_s
+      def handle_input(input)
+        case input
+        when Symbol
+          input.to_s.dasherize
+        when Array
+          input.join(' ').dasherize
+        else
+          input.to_s
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
In some installations, `FaIconParser` and the other Parser classes cannot be found and cause errors when using `fa_icon` and other helper methods.

This PR adds module namespacing that fixes this problem.