### PR TITLE
Support uploaded icons for fontawesome kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,17 +104,18 @@ fa_icon(:camera_retro, text: 'Camera', right: true)
 # => <i class="fas fa-camera-retro"></i>
 ```
 
-### Solid, Regular, Light, Brand, Duotone icon types
+### Solid, Regular, Light, Brand, Duotone, Uploaded icon types
 In Font Awesome 5 there are several different types of icons. In font_awesome5_rails gem default icon type is ```solid```.
 If you want to use different icon style you can do this through ```type``` attribute.
 
-| Style         | type: | type:  |
-| ------------- |-------|--------|
-| Solid         | :fas  |:solid  |
-| Regular       | :far  |:regular|
-| Light         | :fal  |:light  |
-| Brand         | :fab  |:brand  |
-| Duotone       | :fad  |:duotone|
+|Style        | type: | type:   |
+|-------------|-------|---------|
+|Solid        | :fas  |:solid   |
+|Regular      | :far  |:regular |
+|Light        | :fal  |:light   |
+|Brand        | :fab  |:brand   |
+|Duotone      | :fad  |:duotone |
+|Kit Uploaded | :fak  |:uploaded|
 
 
 ```ruby
@@ -135,6 +136,12 @@ fa_icon('camera-retro', type: :duotone)
 
 fa_icon('camera-retro', type: :fab)
 # => <i class="fab fa-camera-retro"></i>
+
+fa_icon('custom-uploaded', type: :fak)
+# => <i class="fak fa-custom-uploaded"></i>
+
+fa_icon('custom-uploaded', type: :uploaded)
+# => <i class="fak fa-custom-uploaded"></i>
 
 ```
 

--- a/app/helpers/font_awesome5/rails/icon_helper.rb
+++ b/app/helpers/font_awesome5/rails/icon_helper.rb
@@ -5,6 +5,7 @@ require 'font_awesome5_rails/parsers/fa_stacked_icon_parser'
 module FontAwesome5
   module Rails
     module IconHelper
+      ICON_TYPES = %w(fas far fal fab fad fak).freeze
 
       def fa5_icon(icon, options = {})
         FontAwesome5Rails::Parsers::FaIconParser.new(icon, options).tag
@@ -34,7 +35,7 @@ module FontAwesome5
         end
       end
 
-      %w(fas far fal fab fad).each do |type|
+      ICON_TYPES.each do |type|
         define_method :"#{type}_icon" do |icon, options = {}|
           options[:type] = type.to_sym unless options.key? :type
           fa_icon(icon, options)

--- a/lib/font_awesome5_rails/parsers/parse_methods.rb
+++ b/lib/font_awesome5_rails/parsers/parse_methods.rb
@@ -13,6 +13,8 @@ module FontAwesome5Rails
           'fab'
         when :fad, :duotone
           'fad'
+        when :fak, :uploaded
+          'fak'
         else
           'fas'
         end

--- a/spec/font_awesome5_rails_spec.rb
+++ b/spec/font_awesome5_rails_spec.rb
@@ -43,11 +43,13 @@ describe FontAwesome5Rails do
         expect(send(subject, 'camera-retro', type: :fal)).to eq '<i class="fal fa-camera-retro"></i>'
         expect(send(subject, 'camera-retro', type: :fab)).to eq '<i class="fab fa-camera-retro"></i>'
         expect(send(subject, 'camera-retro', type: :fad)).to eq '<i class="fad fa-camera-retro"></i>'
+        expect(send(subject, 'camera-retro', type: :fak)).to eq '<i class="fak fa-camera-retro"></i>'
         expect(send(subject, 'camera-retro', type: :solid)).to eq '<i class="fas fa-camera-retro"></i>'
         expect(send(subject, 'camera-retro', type: :regular)).to eq '<i class="far fa-camera-retro"></i>'
         expect(send(subject, 'camera-retro', type: :light)).to eq '<i class="fal fa-camera-retro"></i>'
         expect(send(subject, 'camera-retro', type: :brand)).to eq '<i class="fab fa-camera-retro"></i>'
         expect(send(subject, 'camera-retro', type: :duotone)).to eq '<i class="fad fa-camera-retro"></i>'
+        expect(send(subject, 'camera-retro', type: :uploaded)).to eq '<i class="fak fa-camera-retro"></i>'
       end
 
       it 'should return correct class tags' do


### PR DESCRIPTION
Want to support icons that are uploaded to the Font Awesome kits: `fak`

![Screen Shot 2021-06-04 at 1 34 06 PM](https://user-images.githubusercontent.com/672057/120861025-803a9f80-c53b-11eb-950b-76e39e0c7905.png)