### PR TITLE
Add additional icon options when using with a Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,37 @@ Next import font in your ```app/javascript/packs/application.js```. You can find
 
 Now you have icons installed through webpack and still you can use ```fa_icon``` helpers.
 
+### 4. Install webfont with CSS Bundling and Propshaft
+
+To install the webfont on Rails 7+ with [Propshaft][] and [CSS Bundling][] (using Dart Sass), follow these instructions.
+
+First, add Font Awesome 5 to your ```package.json```:
+
+```shell
+$ npm install "@fortawesome/fontawesome-free@^5.0.0"
+```
+
+Then, copy the fonts to `app/assets`:
+
+```shell
+$ mkdir -p app/assets/fonts
+$ cp -a node_modules/@fortawesome/fontawesome-free/webfonts app/assets/fonts/
+```
+
+Finally, add this to your `app/assets/stylesheets/application.sass.scss`:
+
+```scss
+$fa-font-path: "/webfonts";
+@import "@fortawesome/fontawesome-free/scss/fontawesome";
+@import "@fortawesome/fontawesome-free/scss/regular";
+@import "@fortawesome/fontawesome-free/scss/solid";
+@import "@fortawesome/fontawesome-free/scss/brands";
+@import "@fortawesome/fontawesome-free/scss/v4-shims";
+```
+
+[CSS Bundling]: https://github.com/rails/cssbundling-rails
+[Propshaft]: https://github.com/rails/propshaft
+
 ## Usage
 Gem provides FontAwesome icons through helper. In your views just call `fa_icon`.
 

--- a/README.md
+++ b/README.md
@@ -82,37 +82,6 @@ Next import font in your ```app/javascript/packs/application.js```. You can find
 
 Now you have icons installed through webpack and still you can use ```fa_icon``` helpers.
 
-### 4. Install webfont with CSS Bundling and Propshaft
-
-To install the webfont on Rails 7+ with [Propshaft][] and [CSS Bundling][] (using Dart Sass), follow these instructions.
-
-First, add Font Awesome 5 to your ```package.json```:
-
-```shell
-$ npm install "@fortawesome/fontawesome-free@^5.0.0"
-```
-
-Then, copy the fonts to `app/assets`:
-
-```shell
-$ mkdir -p app/assets/fonts
-$ cp -a node_modules/@fortawesome/fontawesome-free/webfonts app/assets/fonts/
-```
-
-Finally, add this to your `app/assets/stylesheets/application.sass.scss`:
-
-```scss
-$fa-font-path: "/webfonts";
-@import "@fortawesome/fontawesome-free/scss/fontawesome";
-@import "@fortawesome/fontawesome-free/scss/regular";
-@import "@fortawesome/fontawesome-free/scss/solid";
-@import "@fortawesome/fontawesome-free/scss/brands";
-@import "@fortawesome/fontawesome-free/scss/v4-shims";
-```
-
-[CSS Bundling]: https://github.com/rails/cssbundling-rails
-[Propshaft]: https://github.com/rails/propshaft
-
 ## Usage
 Gem provides FontAwesome icons through helper. In your views just call `fa_icon`.
 
@@ -136,7 +105,7 @@ fa_icon(:camera_retro, text: 'Camera', right: true)
 # => <i class="fas fa-camera-retro"></i>
 ```
 
-### Solid, Regular, Light, Brand, Duotone, Uploaded icon types
+### Solid, Regular, Light, Thin, Brand, Duotone, Sharp, Duotone Sharp, Uploaded icon types
 In Font Awesome 5 there are several different types of icons. In font_awesome5_rails gem default icon type is ```solid```.
 If you want to use different icon style you can do this through ```type``` attribute.
 
@@ -146,7 +115,19 @@ If you want to use different icon style you can do this through ```type``` attri
 |Regular      | :far  |:regular |
 |Light        | :fal  |:light   |
 |Brand        | :fab  |:brand   |
+|Thin         | :fat  |:thin    |
 |Duotone      | :fad  |:duotone |
+|Duotone Regular| :fadr |:duotone_regular |
+|Duotone Light | :fadl |:duotone_light |
+|Duotone Thin  | :fadt |:duotone_thin |
+|Sharp        | :fash |:sharp   |
+|Sharp Regular| :fashr |:sharp_regular |
+|Sharp Light  | :fashl |:sharp_light |
+|Sharp Thin   | :fashf |:sharp_thin |
+|Sharp Duotone| :fashd|:sharp_duotone|
+|Sharp Duotone Regular| :fashdr |:sharp_duotone_regular |
+|Sharp Duotone Light | :fashdl |:sharp_duotone_light |
+|Sharp Duotone Thin  | :fashdf |:sharp_duotone_thin |
 |Kit Uploaded | :fak  |:uploaded|
 
 

--- a/app/helpers/font_awesome5/rails/icon_helper.rb
+++ b/app/helpers/font_awesome5/rails/icon_helper.rb
@@ -5,7 +5,7 @@ require 'font_awesome5_rails/parsers/fa_stacked_icon_parser'
 module FontAwesome5
   module Rails
     module IconHelper
-      ICON_TYPES = %w(fas far fal fab fad fak).freeze
+      ICON_TYPES = %w[fas far fal fat fab fad fadr fadl fadt fash fashr fashl fashf fashd fashdr fashdl fashdf fak].freeze
 
       def fa_inline_icon(icon, options = {})
         file = FontAwesome5Rails::Parsers::FaIconParser.new(icon, options).file

--- a/lib/font_awesome5_rails/parsers/parse_methods.rb
+++ b/lib/font_awesome5_rails/parsers/parse_methods.rb
@@ -2,21 +2,47 @@ module FontAwesome5Rails
   module Parsers
     module ParseMethods
       def icon_type(type)
-        return 'fas' if type.nil?
+        return "fa-solid" if type.nil?
 
         case type.to_sym
+        when :fas, :solid
+          "fa-solid"
         when :far, :regular
-          'far'
+          "fa-regular"
         when :fal, :light
-          'fal'
+          "fa-light"
+        when :fat, :thin
+          "fa-thin"
         when :fab, :brand
-          'fab'
+          "fa-brands"
         when :fad, :duotone
-          'fad'
+          "fa-duotone fa-solid"
+        when :fadr, :duotone_regular
+          "fa-duotone fa-regular"
+        when :fadl, :duotone_light
+          "fa-duotone fa-light"
+        when :fadt, :duotone_thin
+          "fa-duotone fa-thin"
+        when :fash, :sharp
+          "fa-sharp fa-solid"
+        when :fashr, :sharp_regular
+          "fa-sharp fa-regular"
+        when :fashl, :sharp_light
+          "fa-sharp fa-light"
+        when :fashf, :sharp_thin
+          "fa-sharp fa-thin"
+        when :fadsh, :sharp_duotone
+          "fa-sharp-duotone fa-solid"
+        when :fadshr, :sharp_duotone_regular
+          "fa-sharp-duotone fa-solid"
+        when :fadshl, :sharp_duotone_light
+          "fa-sharp-duotone fa-light"
+        when :fadshf, :sharp_duotone_thin
+          "fa-sharp-duotone fa-thin"
         when :fak, :uploaded
-          'fak'
+          "fa-kit"
         else
-          'fas'
+          "fa-solid"
         end
       end
 

--- a/lib/font_awesome5_rails/parsers/parse_methods.rb
+++ b/lib/font_awesome5_rails/parsers/parse_methods.rb
@@ -31,13 +31,13 @@ module FontAwesome5Rails
           "fa-sharp fa-light"
         when :fashf, :sharp_thin
           "fa-sharp fa-thin"
-        when :fadsh, :sharp_duotone
+        when :fashd, :sharp_duotone
           "fa-sharp-duotone fa-solid"
-        when :fadshr, :sharp_duotone_regular
-          "fa-sharp-duotone fa-solid"
-        when :fadshl, :sharp_duotone_light
+        when :fashdr, :sharp_duotone_regular
+          "fa-sharp-duotone fa-regular"
+        when :fashdl, :sharp_duotone_light
           "fa-sharp-duotone fa-light"
-        when :fadshf, :sharp_duotone_thin
+        when :fashdf, :sharp_duotone_thin
           "fa-sharp-duotone fa-thin"
         when :fak, :uploaded
           "fa-kit"


### PR DESCRIPTION
This gem works great for us using the Font Awesome Kit with version 6, but limited to the original icon types. This change allows the additional options to be utilized as well.